### PR TITLE
Added Dockerfile based on Debian Jessie LXC image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM quentinlc/jessie-lxc:latest
+
+MAINTAINER Quent Laporte-Chabasse
+
+RUN apt-get update && \
+  curl -sL https://deb.nodesource.com/setup_4.x | bash - && \
+  apt-get install -y nodejs
+
+RUN npm install sigver -g
+
+
+EXPOSE 8000
+
+CMD ["sigver"]


### PR DESCRIPTION
- Added Dockerfile allowing to easily build Sigver server image.
- This image is based on Debian Jessie LXC image, in order to be compliant with experimental environment (Grid5000)
